### PR TITLE
Removes uneeded config import and ensure_exists

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -1,14 +1,9 @@
 name: 'Imagemagick Configuration'
 description: 'Installs and configures Imagemagick for Drupal.'
-type: 'Site'
-
+type: 'System'
 install:
   - imagemagick
 config:
-  import:
-    imagemagick: "*"
-    file_mdm: "*"
-    sophron: "*"
   actions:
     # Update system's image toolkit to imagemagick from the default gd.
     system.image:
@@ -16,7 +11,5 @@ config:
         toolkit: imagemagick
     # Set the quality to 100 from the default 75.
     imagemagick.settings:
-      ensure_exists:
-        id: imagemagick.settings
       simple_config_update:
         quality: 100


### PR DESCRIPTION
The module's simple config are automatically imported if needed.  This was the cause of the issue with reapplying the recipe.

We need to test a fresh install.

## Description
Teamwork Ticket(s): [insert_ticket_name_here](insert_link_here)

> As a developer, I need to start with a story.

_A few sentences describing the overall goals of the pull request's commits.
What is the current behavior of the app? What is the updated/expected behavior
with this PR?_

## Acceptance Criteria
* A list describing how the feature should behave
* e.g. Clicking outside a modal will close it
* e.g. Clicking on a new accordion tab will not close open tabs

## Assumptions
* A list of things the code reviewer or project manager should know
* e.g. There is a known Javascript error in the console.log
* e.g. On any `multidev`, the popup plugin breaks.

## Steps to Validate
1. A list of steps to validate
1. Include direct links to test sites (specific nodes, admin screens, etc)
1. Be explicit

## Affected URL
[link_to_relevant_multidev_or_test_site](insert_link_here)

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc. This should also include work that needs to be 
accomplished post-launch like enabling a plugin._
